### PR TITLE
[pVy3Eu4C] added public endpoint

### DIFF
--- a/standapp.rb
+++ b/standapp.rb
@@ -12,7 +12,7 @@ class Team    < Sequel::Model; end
 
 class StandApp < Sinatra::Base
   get '/' do
-    "Welcome to the StandApp!"
+    "Welcome to the StandApp Public Endpoint!"
   end
 
   get '/users' do

--- a/test/stand_app_test.rb
+++ b/test/stand_app_test.rb
@@ -8,9 +8,27 @@ class StandAppTest < MiniTest::Unit::TestCase
     StandApp
   end
 
-  def test_hello_world
+  def test_welcome_message
     get '/'
     assert last_response.ok?
-    assert_equal "Hello to the StandApp!", last_response.body
+    assert_equal "Welcome to the StandApp Public Endpoint!", last_response.body
+  end
+
+  def test_users_page
+    get '/users'
+    assert last_response.ok?
+    assert_equal "This is the Users page", last_response.body
+  end
+
+  def test_stand_ups_page
+    get '/stand_ups'
+    assert last_response.ok?
+    assert_equal "This is the Stand_ups page", last_response.body
+  end
+
+  def test_teams_page
+    get '/teams'
+    assert last_response.ok?
+    assert_equal "This is the Teams page", last_response.body
   end
 end


### PR DESCRIPTION
This PR is quite empty, because there was already a public endpoint which response to a 200-status, this is the link to the _Trello ticket_:
https://trello.com/c/pVy3Eu4C/7-add-first-public-endpoint-for-an-api-status-that-returns-a-200s

So, basically, i leave all almost like it was, i just changed the welcome string message. Before I get to this conclusion I tried this next code:
```
class StandApp < Sinatra::Base
  def call(env)
    if env["PATH_INFO"] == "/"
      [200, {}, ['Welcome to the StandApp!']]
    elsif env["PATH_INFO"] == "/users"
      [200, {}, ['This is the Users page']]
    elsif env["PATH_INFO"] == "/stand_ups"
      [200, {}, ['This is the Stand_ups page']]
    elsif env["PATH_INFO"] == "/teams"
      [200, {}, ['This is the Teams page']]
    else
      [400, {}, ['Nothing here!']]
    end
  end
end
```

But talking with Jaime, a friend and worker here in michelada.io, he explained to me that this code that I'm submitting already do what the ticket ask for and the example added in this comment works but for a fully Rack based API, and doing so was not following the Sinatra way of developing app's.