### PR TITLE
[iStinePl] authenticity token enabled

### DIFF
--- a/standapp.rb
+++ b/standapp.rb
@@ -2,6 +2,7 @@ require 'rubygems'
 require 'sinatra/base'
 require 'sequel'
 require 'sqlite3'
+require 'rack/protection'
 
 DB = Sequel.connect('sqlite://standapp.db')
 
@@ -11,6 +12,9 @@ class StandUp < Sequel::Model; end
 class Team    < Sequel::Model; end
 
 class StandApp < Sinatra::Base
+  enable :sessions
+  use Rack::Protection::AuthenticityToken
+
   get '/' do
     "Welcome to the StandApp!"
   end


### PR DESCRIPTION
I have enabled the sessions for the API in order to use the authenticity token to prevent for CSRF attacks as this ticket asks for:
https://trello.com/c/iStinePl/8-add-authentication-token-base-for-non-public-requests

I found wisdom and guideness here:
http://sinatrarb.com/faq.html#sessions
http://sinatrarb.com/intro.html#Using%20Sessions
https://github.com/sinatra/sinatra/tree/master/rack-protection

But I feel like this was so little effort that I might be missing something.